### PR TITLE
Fix printing using patch from AUR package prior to this

### DIFF
--- a/lib/src/printhandler.cpp
+++ b/lib/src/printhandler.cpp
@@ -142,8 +142,8 @@ void PrintHandler::print(Poppler::Document *popplerDocument, QList<Poppler::Page
 	int startPage, endPage;
 	if (printer.printRange() == QPrinter::PageRange)
 	{
-		startPage = printer.fromPage() - 1;
-		endPage = printer.toPage() - 1;
+		startPage = printer.fromPage();
+		endPage = printer.toPage();
 	}
 	else if (printer.printRange() == QPrinter::CurrentPage)
 	{
@@ -152,8 +152,8 @@ void PrintHandler::print(Poppler::Document *popplerDocument, QList<Poppler::Page
 	}
 	else
 	{
-		startPage = 0;
-		endPage = popplerDocument->numPages() - 1;
+		startPage = 1;
+		endPage = popplerDocument->numPages();
 	}
 
 	// print
@@ -179,27 +179,34 @@ void PrintHandler::print(Poppler::Document *popplerDocument, QList<Poppler::Page
 	if (!printer.printerName().isEmpty())
 	{
 		QStringList args;
-		if (!printer.printerName().contains(QLatin1Char(' ')))
-			args << QString(QLatin1String("-d %1")).arg(printer.printerName());
-		args << QString(QLatin1String("-n %1")).arg(printer.copyCount());
-		args << QString(QLatin1String("-P %1-%2")).arg(startPage).arg(endPage);
+		if (!printer.printerName().contains(QLatin1Char(' '))) {
+			args << QString(QLatin1String("-d"));
+			args << printer.printerName();
+		}
+		args << QString(QLatin1String("-n"));
+		args << QString(QLatin1String("%1")).arg(printer.copyCount());
+		args << QString(QLatin1String("-P"));
+		args << QString(QLatin1String("%1-%2")).arg(startPage).arg(endPage);
 		switch(printer.duplex())
 		{
 			case QPrinter::DuplexNone:
-				args << QLatin1String("-o sides=one-sided");
+				args << QLatin1String("-o");
+				args << QLatin1String("sides=one-sided");
 				break;
 			case QPrinter::DuplexShortSide:
-				args << QLatin1String("-o sides=two-sided-short-edge");
+				args << QLatin1String("-o");
+				args << QLatin1String("sides=two-sided-short-edge");
 				break;
 			case QPrinter::DuplexLongSide:
-				args << QLatin1String("-o sides=two-sided-long-edge");
+				args << QLatin1String("-o");
+				args << QLatin1String("sides=two-sided-long-edge");
 				break;
 			default:
 				break;
 		}
 		args << cupsOptions();
 		args << QLatin1String("--");
-		args << QString(QLatin1String("\"%1\"")).arg(fileName);
+		args << QString(QLatin1String("%1")).arg(fileName);
 
 //		QProcess::execute(PDFVIEWLIB_PRINT_PROGRAM, args);
 		QProcess::startDetached(QString::fromLocal8Bit(PDFVIEWLIB_PRINT_PROGRAM), args);


### PR DESCRIPTION
Original source of patch: https://gist.github.com/ShadowKyogre/5249804

More specifically, it was surrounding the arguments with literal quotes and
handled the page numbers in a way that lpr could not handle. Arguments
added to a string list are treated literally and so should not be requoted.

Just make sure that the start page and end page indexing doesn't break 
under windows too since I didn't test that yet.
